### PR TITLE
Add an option for generating factory recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,21 @@ To generate multiple factories at once, run the artisan command:
 
 This command will find all models within your application and create test factories.
 
+---
+
 To generate a factory for only specific model or models, run the artisan command:
 
 `php artisan generate:factory User Company`
+
+---
 
 By default, generation will not overwrite any existing model factories.
 
 You can _force_ overwriting existing model factories by using the `--force` option:
 
 `php artisan generate:factory --force`
+
+---
 
 By default, it will search recursively for models under the `app/Models` (Laravel/Lumen 8.x) or `app` for (Laravel/Lumen 6.x and 7.x).
 
@@ -46,11 +52,23 @@ In this case, run the artisan command:
 
 `php artisan generate:factory --dir app/Models`
 
+---
+
 If your models are within a different namespace, you can specify it using `--namespace` option.
 
 You just need to execute this artisan command:
 
 `php artisan generate:factory --dir vendor/package/src/Models --namespace CustomNamespace\\Models`
+
+---
+
+By default, your model directory structure is not taken into account, even though it has subdirectories.
+
+You can reflect it to `database/factories` directory by using the `--recursive` option:
+
+`php artisan generate:factory --recursive`
+
+---
 
 ### Example
 

--- a/resources/views/class-factory.blade.php
+++ b/resources/views/class-factory.blade.php
@@ -1,4 +1,4 @@
-namespace Database\Factories;
+namespace {{'Database\\Factories'. $append}};
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 @isset($properties['remember_token'])

--- a/src/Console/GenerateFactoryCommand.php
+++ b/src/Console/GenerateFactoryCommand.php
@@ -97,7 +97,7 @@ class GenerateFactoryCommand extends Command
             $class = class_basename($model);
             $filename = "database/factories/{$class}Factory.php";
 
-            $class = $this->namespace ? $this->namespace . '\\' . $class : $model;
+            $class = $this->generateClassName($model);
 
             if ($this->recursive) {
                 $filename = $this->generateRecursiveFileName($class);
@@ -513,6 +513,13 @@ class GenerateFactoryCommand extends Command
     protected function generateRecursiveFileName(string $class): string
     {
         return 'database/factories/' . implode('/', $this->getFileStructureDiff($class)) . 'Factory.php';
+    }
+
+    protected function generateClassName(string $model): string
+    {
+        $filePathDiff = $this->getFileStructureDiff($model);
+
+        return $this->namespace ? $this->namespace . '\\' . implode('\\', $filePathDiff) : $model;
     }
 
     protected function generateAdditionalNameSpace(string $class): string


### PR DESCRIPTION
**Summary**

Added an option (--recursive, -R) for generating factory recursively.
This means that you can create factories following in your `Models` directory structure when you execute artisan command with  the --recursive option.

--------------------------------------------------------------------------------
**Example**

```bash
Model directory structure

project
├── README.md
├── app
│   └──Models
│      ├── User.php
│      └── dir
│           ├── FailedJob.php
│           └── dir_more
│               └── PasswordReset.php
├── database
│   └── factories
└──     
```


Artisan command
`php artisan generate:factory --recursive`

or

`php artisan generate:factory -R`


```bash
Result

project
├── README.md
├── app
│   └──Models
│       ├── User.php
│       └── dir
│           ├── FailedJob.php
│           └── dir_more
│               └── PasswordReset.php
├── database
│   └── factories
│       ├── UserFactory.php
│       └── dir
│             ├── FailedJobFactory.php
│             └── dir_more
│                 └── PasswordResetFactory.php
└──     
```

--------------------------------------------------------------------------------

**In conslusion**

In my projects, there are a lot of subdirectories in `App/Models` directory to organize model classes well. 
Therefore, I would like to organize factories in the same way that I do towards App/Models directory.
That's why I added this feature.

I hope you are going to like it.

Thank you.