### PR TITLE
Add `@extends` property for Larastan users

### DIFF
--- a/resources/views/class-factory.blade.php
+++ b/resources/views/class-factory.blade.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Str;
 @endisset
 use {{ $reflection->getName() }};
 
+/**
+ * @extends Factory<{{ $reflection->getShortName() }}>
+ */
 class {{ $reflection->getShortName() }}Factory extends Factory
 {
     /**


### PR DESCRIPTION
This makes the generated class work nicely with Larastan, which uses this extension to improve type safety with factory usage - see https://github.com/nunomaduro/larastan/blob/65cfc54fa195e509c2e2be119761552017d22a56/tests/Application/database/factories/UserFactory.php#L11-L14
and https://github.com/nunomaduro/larastan/blob/65cfc54fa195e509c2e2be119761552017d22a56/stubs/Factory.stub#L5-L8.

Users not using Larastan can simply remove the annotation, it does not cause issues for them.