### PR TITLE
Added support for Laravel 11.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,9 @@
     "license": "MIT",
     "require": {
         "php": ">=7.4",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/filesystem": "^8.0|^9.0|^10.0",
-        "doctrine/dbal": "^2.9|^2.10|^3.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=7.4",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0",
+        "doctrine/dbal": "^2.9|^2.10|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dropped "doctrine/dbal" as it is no longer needed for Laravel 11.x

Added version constraints for: _illuminate/support, illuminate/console, illuminate/filesystem_