### PR TITLE
Add support for `tinyint` type

### DIFF
--- a/src/Console/GenerateFactoryCommand.php
+++ b/src/Console/GenerateFactoryCommand.php
@@ -402,6 +402,7 @@ class GenerateFactoryCommand extends Command
             'integer' => $this->fakerPrefix('randomNumber()', $nullable),
             'bigint' => $this->fakerPrefix('randomNumber()', $nullable),
             'smallint' => $this->fakerPrefix('randomNumber()', $nullable),
+            'tinyint' => $this->fakerPrefix('randomNumber(1)', $nullable),
             'decimal' => $this->fakerPrefix('randomFloat()', $nullable),
             'float' => $this->fakerPrefix('randomFloat()', $nullable),
             'boolean' => $this->fakerPrefix('boolean', $nullable),


### PR DESCRIPTION
When trying to generate a factory for a model/table with a field of type `tinyint`, the library will generate a value with `fake()->word`. That's because `tinyint` is not currently a registered type option, which causes the lib to fall back onto the `xtring` type.

This PR adds the `tinyint` type, allowing values from 0 to 9 to be generated randomly for that field.